### PR TITLE
go get is now go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ There is a reference implementation for the compiler, `mexico`, and a reference 
 
 ### Compiler "mexico"
 
-Simply run `go get github.com/maride/mexico/mexico` to get the compiler.
+Simply run `go install github.com/maride/mexico/mexico@latest` to get the compiler.
 
 The mexico compiler takes three arguments:
 


### PR DESCRIPTION
```bash
; go get github.com/maride/mexico/mexico         /Users/emile/Documents/Projects/<redacted>
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```	